### PR TITLE
Change JsonLoader To Accept Compressed Files

### DIFF
--- a/src/Jmem/JsonLoader.php
+++ b/src/Jmem/JsonLoader.php
@@ -38,8 +38,11 @@ class JsonLoader implements LoaderInterface {
      * @throws \Exception
      */
 	public function setFile($file) {
-
-        if(is_readable($file)) {
+        $f = $file;
+        if (preg_match('#^compress\.(.*)://(.*)#', $file, $r)) {
+            $f = $r[2];
+        }
+        if(is_readable($f)) {
             $open = fopen($file, "rb");
             $this->file = $open;
         } else {


### PR DESCRIPTION
For very large Hangout.json files, allow compressed gzip file to be passed using the php compress.zlib:// wrapper